### PR TITLE
Add: SonarQube Plugin LWRP

### DIFF
--- a/attributes/plugin.rb
+++ b/attributes/plugin.rb
@@ -1,0 +1,3 @@
+default['sonarqube']['plugin']['mirror'] = 'https://sonarsource.bintray.com/Distribution'
+
+default['sonarqube']['plugin']['dir'] = "/opt/sonarqube-#{node['sonarqube']['version']}/extensions/plugins"

--- a/resources/plugin.rb
+++ b/resources/plugin.rb
@@ -1,0 +1,49 @@
+property :plugin_name, String, name_property: true
+property :version, String
+
+actions :install, :uninstall
+default_action :install
+
+sonarqube_user = node['sonarqube']['user']
+sonarqube_group = node['sonarqube']['group']
+
+action :install do
+  service 'sonarqube' do
+    action :nothing
+  end
+
+  remote_file plugin_path do
+    source plugin_url
+    mode 0755
+    owner sonarqube_user
+    group sonarqube_group
+    notifies :restart, 'service[sonarqube]', :delayed
+  end
+end
+
+action :uninstall do
+  service 'sonarqube' do
+    action :nothing
+  end
+
+  file plugin_path do
+    action :delete
+    notifies :restart, 'service[sonarqube]', :delayed
+  end
+end
+
+def plugin_url
+  sonarqube_plugin_mirror = node['sonarqube']['plugin']['mirror']
+
+  "#{sonarqube_plugin_mirror}/sonar-#{plugin_name}-plugin/#{plugin_file_name}"
+end
+
+def plugin_path
+  sonarqube_plugin_dir = node['sonarqube']['plugin']['dir']
+
+  ::File.join(sonarqube_plugin_dir, plugin_file_name)
+end
+
+def plugin_file_name
+  "sonar-#{plugin_name}-plugin-#{version}.jar"
+end

--- a/test/fixtures/cookbooks/sonarqube_plugin_consumer/metadata.rb
+++ b/test/fixtures/cookbooks/sonarqube_plugin_consumer/metadata.rb
@@ -1,0 +1,2 @@
+name 'sonarqube_plugin_consumer'
+depends 'sonarqube'

--- a/test/fixtures/cookbooks/sonarqube_plugin_consumer/recipes/default.rb
+++ b/test/fixtures/cookbooks/sonarqube_plugin_consumer/recipes/default.rb
@@ -1,0 +1,3 @@
+sonarqube_plugin 'groovy' do
+  version '1.3'
+end

--- a/test/integration/sonarqube_plugin/serverspec/assert_plugin_installation_spec.rb
+++ b/test/integration/sonarqube_plugin/serverspec/assert_plugin_installation_spec.rb
@@ -1,0 +1,9 @@
+require 'serverspec'
+
+set :backend, :exec
+
+describe file('/opt/sonarqube-5.1.2/extensions/plugins/sonar-groovy-plugin-1.3.jar') do
+  it { should be_file }
+  it { should be_readable.by_user('sonarqube') }
+  it { should be_executable.by_user('sonarqube') }
+end


### PR DESCRIPTION
Downloads plugins from the SonarQube distribution site
(https://sonarsource.bintray.com/Distribution/) and installs to an
existing SQ instance.

LWRP syntax is borrowed from the jenkins_plugin LWRP.