### PR TITLE
Enhance plugin installation mechanism and add ldap plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,50 @@ to install a suitable Oracle JDK or OpenJDK.
 
 ### default
 Installs SonarQube Server and manages `sonar.properties`.
+In case that *-plugin.conf.erb templates available and plugin list defined, their data will be added to sonar.properties
 
 ### scanner
 Installs SonarQube Scanner and manages `sonar-runner.properties`.
 Adds the SonarQube Scanner to all users' `PATH` via `/etc/profile.d`.
+
+### plugins
+Installs SonarQube plugins according to the data in node['sonarqube']['plugin']['list'] attribute
+node['sonarqube']['plugin']['list'] hash should contain the following data:
+```
+{
+   plugin_name_without_sonar_prefix: {
+        "version": version,
+        "template": true (in case that configuration should be in sonar.properties) [false] by default
+    }
+}
+```
+
+Example in role:
+```
+"sonarqube": {
+  "plugin": {
+    "list": {
+      "ldap": {
+        "version": "2.1.0.507",
+        "template": true
+      },
+      "python": {
+        "version": "1.8.0.1496"
+      },
+      "java": {
+        "version": "4.10.0.10260"
+      },
+      "javascript": {
+        "version": "3.1.0.5111"
+      }
+    }
+  }
+}
+```
+
+In case configuration parameters should be added to sonar.properties please follow next steps:
+1. In case that *_plugin.conf.erb template already exists, please set the relevant parameters
+2. If *_plugin.conf.erb template doesn't exists, please create the relevant template
 
 ## LWRP
 

--- a/attributes/plugin.rb
+++ b/attributes/plugin.rb
@@ -1,3 +1,9 @@
 default['sonarqube']['plugin']['mirror'] = 'https://sonarsource.bintray.com/Distribution'
 
 default['sonarqube']['plugin']['dir'] = "/opt/sonarqube-#{node['sonarqube']['version']}/extensions/plugins"
+
+# hash with plugin:version pairs like
+# default['sonarqube']['plugin']['list'] = { 'ldap' {"version" => '2.1.0.507', 'template' => true }}
+# plugin that is mentioned enables its configuration
+# (in sonar we cannot disable plugin we can either install it or uninstall it)
+default['sonarqube']['plugin']['list'] = {}

--- a/resources/plugin.rb
+++ b/resources/plugin.rb
@@ -12,6 +12,13 @@ action :install do
     action :nothing
   end
 
+  # we need to remove previous plugin versions first
+  Dir[plugin_file_name_wildcard].each do |path|
+    file ::File.expand_path(path) do
+      action :delete
+    end
+  end
+
   remote_file plugin_path do
     source plugin_url
     mode 0755
@@ -46,4 +53,9 @@ end
 
 def plugin_file_name
   "sonar-#{plugin_name}-plugin-#{version}.jar"
+end
+
+def plugin_file_name_wildcard
+  plugin_file_name_without_version = "sonar-#{plugin_name}-plugin-*"
+  ::File.join(node['sonarqube']['plugin']['dir'], plugin_file_name_without_version)
 end

--- a/templates/default/sonar.properties.erb
+++ b/templates/default/sonar.properties.erb
@@ -185,3 +185,10 @@ sonar.rails.dev=<%= node['sonarqube']['rails']['dev'] %>
 <% node['sonarqube']['extra_properties'].each do |p| %>
 <%= p %>
 <% end %>
+
+# add plugins configuration
+<% node['sonarqube']['plugin']['list'].each_pair do |k, v| -%>
+ <% if v.fetch('template', false) -%>
+  <%= render "#{k}_plugin.conf.erb" %>
+ <% end -%>
+<% end -%>


### PR DESCRIPTION
Allows plugin configuration installation

Fixes this issue with plugin installation (at least with sonar 6.3.1). In case that plugin was already installed, plugin install with newer version will end up with two plugin jars and sonar will fail to run.

Adds ldap plugin configuration template

Old PR (https://github.com/christianewillman/sonarqube/pull/25) could be closed (sorry for the mess)