### PR TITLE
Remove default values for connection to DBs

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,11 +15,11 @@ default['sonarqube']['web']['port'] = 9000
 default['sonarqube']['web']['https']['port'] = -1 # Default value of -1 leaves https disabled
 
 default['sonarqube']['embeddedDatabase']['dataDir'] = nil
-default['sonarqube']['embeddedDatabase']['port'] = 9092
+default['sonarqube']['embeddedDatabase']['port'] = nil
 
 default['sonarqube']['jdbc']['username'] = 'sonar'
 default['sonarqube']['jdbc']['password'] = 'sonar'
-default['sonarqube']['jdbc']['url'] = 'jdbc:h2:tcp://localhost:9092/sonar'
+default['sonarqube']['jdbc']['url'] = nil
 
 default['sonarqube']['jdbc']['maxActive'] = 20
 default['sonarqube']['jdbc']['maxIdle'] = 5


### PR DESCRIPTION
The usage of default values duplicates the Sonarqube logic.
Also, when specifying another connection than H2, it leads to have both set:

  sonar.embeddedDatabase.port=9092
  sonar.jdbc.url=jdbc:postgresql://localhost/sonar

which prevents the use of PostgreSQL as explained in this warning
emitted by SonarQube 7.7:

  org.sonar.application.config.JdbcSettings - Both
  'JDBC_EMBEDDED_PORT' and 'JDBC_URL' properties are set. The value of
  property 'JDBC_URL' ('jdbc:postgresql://localhost/sonar') is not
  consistent with the value of property 'JDBC_EMBEDDED_PORT'
  ('9092'). The value of property 'JDBC_URL' will be ignored and value
  'jdbc:h2:tcp://127.0.0.1:9092/sonar' will be used instead. To remove
  this warning, either remove property 'JDBC_URL' if your intent was
  to use the embedded H2 database, otherwise remove property
  'JDBC_EMBEDDED_PORT'.